### PR TITLE
Update: constrain searched gene seeds by network in a random run;

### DIFF
--- a/src/main/java/org/cbio/mutex/Main.java
+++ b/src/main/java/org/cbio/mutex/Main.java
@@ -184,6 +184,7 @@ public class Main
 
 		MutexGreedySearcher searcher = new MutexGreedySearcher(genesMap, network);
 		Set<String> symbols = genesMap.keySet();
+		if (network != null) symbols.retainAll(network.getSymbols());
 		Set<String> noShuffle = loadHighlySignificantGenes();
 		generateRandomPvals(searcher, symbols, noShuffle, null, howMany);
 	}


### PR DESCRIPTION
I run Mutex on a large dataset(25000 genes * 500 patients), and the it consumes much time on a random run. Hence I prefer to constrain the searched gene sets to save some time.